### PR TITLE
fix buffer overflow when input length less than block size

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -510,9 +510,6 @@ void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length,
   const intptr_t full_blocks = length / KEYLEN;
   const uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
 
-  BlockCopy(output, input);
-  state = (state_t*)output;
-
   // Skip the key expansion if key is passed as 0
   if(0 != key)
   {
@@ -552,9 +549,6 @@ void AES128_CBC_decrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length,
   const intptr_t full_blocks = length / KEYLEN;
   const uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
   
-  BlockCopy(output, input);
-  state = (state_t*)output;
-
   // Skip the key expansion if key is passed as 0
   if(0 != key)
   {


### PR DESCRIPTION
Just remove a useless block copy.
This copy is done below anyway and is not needed meanwhile.